### PR TITLE
modification de l'URL du bouton "Edit this page"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,7 +47,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/THP-Lab/thp-lab.github.io/tree/master",
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
Le bouton "Edit this page" renvoi maintenant vers le Github de THP-lab au lieu de celui de Docusaurus